### PR TITLE
기본 도메인 엔티티 및 연관 관계 설정 추가

### DIFF
--- a/src/main/java/com/example/daobe/lounge/entity/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/entity/Lounge.java
@@ -1,0 +1,53 @@
+package com.example.daobe.lounge.entity;
+
+import com.example.daobe.objet.entity.Objet;
+import com.example.daobe.shared.entity.UserLounge;
+import com.example.daobe.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "lounges")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Lounge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lounge_id")
+    private Long loungeId;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @OneToMany(mappedBy = "lounge")
+    private List<Objet> objets;
+
+    @OneToMany(mappedBy = "lounge")
+    private List<UserLounge> userLounges;
+}

--- a/src/main/java/com/example/daobe/lounge/entity/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/entity/Lounge.java
@@ -45,6 +45,9 @@ public class Lounge {
     @Column(name = "reason")
     private String reason;
 
+    @Column(columnDefinition = "TEXT", name = "reason_detail")
+    private String reasonDetail;
+
     @OneToMany(mappedBy = "lounge")
     private List<Objet> objets;
 

--- a/src/main/java/com/example/daobe/myroom/entity/MyRoom.java
+++ b/src/main/java/com/example/daobe/myroom/entity/MyRoom.java
@@ -1,0 +1,37 @@
+package com.example.daobe.myroom.entity;
+
+import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "myrooms")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyRoom extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "myroom_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    // 마이룸 별명
+    private String name;
+
+    // TODO: ENUM 으로 수정 예정
+    // 마이룸 타임 ex) R0001, R0002
+    private String type;
+}

--- a/src/main/java/com/example/daobe/notification/entity/Notification.java
+++ b/src/main/java/com/example/daobe/notification/entity/Notification.java
@@ -1,0 +1,38 @@
+package com.example.daobe.notification.entity;
+
+import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "noti_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    // 알림 타입 ex) N0001, N0002
+    private String type;
+
+    @Column(name = "is_read")
+    private boolean isRead;
+}

--- a/src/main/java/com/example/daobe/objet/entity/Objet.java
+++ b/src/main/java/com/example/daobe/objet/entity/Objet.java
@@ -1,0 +1,56 @@
+package com.example.daobe.objet.entity;
+
+import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.lounge.entity.Lounge;
+import com.example.daobe.shared.entity.UserObjet;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "objets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Objet extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "objet_id")
+    private Long objetId;
+
+    @JoinColumn(name = "lounge_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Lounge lounge;
+
+    @OneToMany(mappedBy = "objet")
+    private List<UserObjet> userObjets;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "explanation")
+    private String explanation;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "reason")
+    private String reason;
+}

--- a/src/main/java/com/example/daobe/objet/entity/Objet.java
+++ b/src/main/java/com/example/daobe/objet/entity/Objet.java
@@ -53,4 +53,7 @@ public class Objet extends BaseTimeEntity {
 
     @Column(name = "reason")
     private String reason;
+
+    @Column(columnDefinition = "TEXT", name = "reason_detail")
+    private String reasonDetail;
 }

--- a/src/main/java/com/example/daobe/shared/entity/UserLounge.java
+++ b/src/main/java/com/example/daobe/shared/entity/UserLounge.java
@@ -1,0 +1,36 @@
+package com.example.daobe.shared.entity;
+
+import com.example.daobe.lounge.entity.Lounge;
+import com.example.daobe.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "users_lounges")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLounge {
+
+    @Id
+    @Column(name = "usr_lng_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "lounge_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Lounge lounge;
+}

--- a/src/main/java/com/example/daobe/shared/entity/UserObjet.java
+++ b/src/main/java/com/example/daobe/shared/entity/UserObjet.java
@@ -1,0 +1,36 @@
+package com.example.daobe.shared.entity;
+
+import com.example.daobe.objet.entity.Objet;
+import com.example.daobe.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "users_objets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserObjet {
+
+    @Id
+    @Column(name = "usr_obj_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "objet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Objet objet;
+}

--- a/src/main/java/com/example/daobe/user/entity/User.java
+++ b/src/main/java/com/example/daobe/user/entity/User.java
@@ -1,0 +1,41 @@
+package com.example.daobe.user.entity;
+
+import com.example.daobe.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id")
+    private Long kakaoId;
+
+    private String nickname;
+
+    @Column(name = "profile_url")
+    private String profileUrl;
+
+    private String status;
+
+    // 비활성화 사유
+    private String reason;
+
+    // 비활성화 사유
+    @Column(columnDefinition = "TEXT")
+    private String reasonDetail;
+}

--- a/src/main/java/com/example/daobe/user/entity/User.java
+++ b/src/main/java/com/example/daobe/user/entity/User.java
@@ -36,6 +36,6 @@ public class User extends BaseTimeEntity {
     private String reason;
 
     // 비활성화 사유
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", name = "reason_detail")
     private String reasonDetail;
 }


### PR DESCRIPTION
## 📝 개요

- 기본 도메인 엔티티 및 연관 관계 설정 추가

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 라운지 도메인 엔티티 추가
    - ✨ 마이룸 도메인 엔티티 추가
    - ✨ 알림 도메인 엔티티 추가
    - ✨ 사용자 도메인 엔티티 추가
    - ✨ 오브제 도메인 엔티티 추가
