### PR TITLE
알림 조회 및 사용자 검색시 발생하던 오류 수정

### DIFF
--- a/src/main/java/com/example/daobe/notification/application/NotificationService.java
+++ b/src/main/java/com/example/daobe/notification/application/NotificationService.java
@@ -13,12 +13,10 @@ import com.example.daobe.notification.domain.repository.dto.NotificationFindCond
 import com.example.daobe.notification.exception.NotificationException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -40,7 +38,7 @@ public class NotificationService {
                 .map(this::convertNotificationDomainInfo)
                 .toList();
         if (notificationSlice.hasNext()) {
-            Long nextCursor = notificationInfoList.get(notificationSlice.getSize() - 1).notificationId();
+            Long nextCursor = notificationInfoList.get(notificationInfoList.size() - 1).notificationId();
             return PagedNotificationInfoResponseDto.of(notificationSlice.hasNext(), nextCursor, notificationInfoList);
         }
         return PagedNotificationInfoResponseDto.of(notificationSlice.hasNext(), notificationInfoList);

--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
 
     // TODO: 리팩토링
 
-    private static final int DEFAULT_VIEW_LIMIT_SIZE = 1;
+    private static final int DEFAULT_VIEW_LIMIT_SIZE = 10;
     private static final int DEFAULT_EXECUTE_LIMIT_SIZE = DEFAULT_VIEW_LIMIT_SIZE + 1;
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
알림 목록 조회시 `Out of Index` 오류가 뜨던 문제 및 사용자 검색시 1명씩 뜨던 문제 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 알림 목록 조회시 인덱스 초과 오류 뜨던 문제 해결
- ✨ 사용자 검색시 기본 결과 10으로 변경
