### PR TITLE
S3 Presigned URL 발행 기능 추가

### DIFF
--- a/src/main/java/com/example/daobe/common/config/S3Config.java
+++ b/src/main/java/com/example/daobe/common/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
@@ -18,6 +19,14 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .credentialsProvider(awsCredentialsProvider())
+                .region(Region.of(properties.region()))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .credentialsProvider(awsCredentialsProvider())
                 .region(Region.of(properties.region()))
                 .build();

--- a/src/main/java/com/example/daobe/upload/application/ImageClient.java
+++ b/src/main/java/com/example/daobe/upload/application/ImageClient.java
@@ -5,4 +5,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageClient {
 
     String upload(String objectKey, MultipartFile file);
+
+    String getUploadUrl(String objectKey);
+
+    String getImageUrl(String objectKey);
 }

--- a/src/main/java/com/example/daobe/upload/application/UploadService.java
+++ b/src/main/java/com/example/daobe/upload/application/UploadService.java
@@ -1,6 +1,7 @@
 package com.example.daobe.upload.application;
 
 import com.example.daobe.upload.application.dto.UploadImageResponseDto;
+import com.example.daobe.upload.application.dto.UploadImageUrlResponseDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,9 +13,17 @@ public class UploadService {
 
     private final ImageClient imageClient;
 
+    @Deprecated(since = "2024-10-21")
     public UploadImageResponseDto upload(MultipartFile file) {
         String objectKey = UUID.randomUUID().toString();
         String imageUrl = imageClient.upload(objectKey, file);
         return UploadImageResponseDto.of(imageUrl);
+    }
+
+    public UploadImageUrlResponseDto getUploadUrl() {
+        String objectKey = UUID.randomUUID().toString();
+        String imageUrl = imageClient.getImageUrl(objectKey);
+        String uploadUrl = imageClient.getUploadUrl(objectKey);
+        return new UploadImageUrlResponseDto(imageUrl, uploadUrl);
     }
 }

--- a/src/main/java/com/example/daobe/upload/application/dto/UploadImageUrlResponseDto.java
+++ b/src/main/java/com/example/daobe/upload/application/dto/UploadImageUrlResponseDto.java
@@ -1,0 +1,7 @@
+package com.example.daobe.upload.application.dto;
+
+public record UploadImageUrlResponseDto(
+        String imageUrl,
+        String uploadUrl
+) {
+}

--- a/src/main/java/com/example/daobe/upload/infrastructure/s3/S3ImageClient.java
+++ b/src/main/java/com/example/daobe/upload/infrastructure/s3/S3ImageClient.java
@@ -5,23 +5,42 @@ import com.example.daobe.upload.application.ImageClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
 @RequiredArgsConstructor
 public class S3ImageClient implements ImageClient {
 
+    private static final String CACHE_CONTROL_PREFIX = "max-age=";
+
     private final S3Uploader s3Uploader;
     private final S3Properties properties;
+    private final S3PresignHandler s3PresignedUrlGenerator;
 
     @Override
     public String upload(String objectKey, MultipartFile file) {
         String bucketName = properties.bucketName();
         int cacheTimeSeconds = properties.cacheTimeSeconds();
         s3Uploader.upload(cacheTimeSeconds, bucketName, objectKey, file);
-        return generatedImageUrl(objectKey);
+        return getImageUrl(objectKey);
     }
 
-    private String generatedImageUrl(String objectKey) {
+    @Override
+    public String getUploadUrl(String objectKey) {
+        PutObjectRequest request = generateRequest(objectKey);
+        return s3PresignedUrlGenerator.execute(request);
+    }
+
+    @Override
+    public String getImageUrl(String objectKey) {
         return properties.imageUrl() + objectKey;
+    }
+
+    private PutObjectRequest generateRequest(String objectKey) {
+        return PutObjectRequest.builder()
+                .bucket(properties.bucketName())
+                .key(objectKey)
+                .cacheControl(CACHE_CONTROL_PREFIX + properties.cacheTimeSeconds())
+                .build();
     }
 }

--- a/src/main/java/com/example/daobe/upload/infrastructure/s3/S3PresignHandler.java
+++ b/src/main/java/com/example/daobe/upload/infrastructure/s3/S3PresignHandler.java
@@ -1,0 +1,25 @@
+package com.example.daobe.upload.infrastructure.s3;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignHandler {
+
+    private static final long PRESIGNED_URL_EXPIRE_SECONDS = 60 * 5;
+
+    private final S3Presigner s3Presigner;
+
+    public String execute(PutObjectRequest request) {
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(PRESIGNED_URL_EXPIRE_SECONDS))
+                .putObjectRequest(request)
+                .build();
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+}

--- a/src/main/java/com/example/daobe/upload/presentation/UploadController.java
+++ b/src/main/java/com/example/daobe/upload/presentation/UploadController.java
@@ -2,8 +2,10 @@ package com.example.daobe.upload.presentation;
 
 import com.example.daobe.upload.application.UploadService;
 import com.example.daobe.upload.application.dto.UploadImageResponseDto;
+import com.example.daobe.upload.application.dto.UploadImageUrlResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,10 +19,16 @@ public class UploadController {
 
     private final UploadService uploadService;
 
+    @Deprecated(since = "2024-10-21")
     @PostMapping("/images")
     public ResponseEntity<UploadImageResponseDto> uploadImage(
             @RequestParam("file") MultipartFile file
     ) {
         return ResponseEntity.ok(uploadService.upload(file));
+    }
+
+    @GetMapping("/url")
+    public ResponseEntity<UploadImageUrlResponseDto> uploadUrl() {
+        return ResponseEntity.ok(uploadService.getUploadUrl());
     }
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
이미지 업로드 기능이 서버 리소스를 가장 많이 사용하여 코어 로직에 영향을 줄 수 있다고 판단하여, 클라이언트가 직접 S3 에 접근 가능한 `Presigned URL` 을 제공함으로 써 해당 문제를 개선
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `Presigned URL` 발급 로직 추가
- ✨ 기존에 사용하던 로직 `@Deprecated`

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #297 

## ℹ️ 참고 사항

- 프론트엔드에서 이미지 업로드 로직이 수정되면 기존 로직은 삭제할 예정입니다.