### PR TITLE
데이터 소스 설정과 스케쥴러 설정 수정 및 레디스 확장 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ repositories {
 }
 
 dependencies {
+    // custom redis pub sub
+    implementation 'io.github.jihongkim98:redis-extensions:0.0.1'
+
     // Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -39,7 +42,7 @@ dependencies {
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/src/main/java/com/example/daobe/common/config/JpaConfig.java
+++ b/src/main/java/com/example/daobe/common/config/JpaConfig.java
@@ -1,9 +1,22 @@
 package com.example.daobe.common.config;
 
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 @Configuration
 @EnableJpaAuditing
+@EnableJpaRepositories(
+        basePackages = {
+                "com.example.daobe.common.outbox",
+                "com.example.daobe.*.domain.repository",
+        },
+        excludeFilters = {
+                @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MongoRepository.class),
+        }
+)
 public class JpaConfig {
 }

--- a/src/main/java/com/example/daobe/common/config/MongoConfig.java
+++ b/src/main/java/com/example/daobe/common/config/MongoConfig.java
@@ -1,8 +1,10 @@
 package com.example.daobe.common.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
@@ -10,18 +12,24 @@ import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
 @EnableMongoAuditing
-@RequiredArgsConstructor
+@EnableMongoRepositories(
+        basePackages = {
+                "com.example.daobe.*.domain.repository",
+        },
+        excludeFilters = {
+                @Filter(type = FilterType.ASSIGNABLE_TYPE, value = JpaRepository.class),
+        }
+)
 public class MongoConfig {
-
-    private final MongoMappingContext mongoMappingContext;
 
     @Bean
     public MappingMongoConverter mappingMongoConverter(
-            MongoDatabaseFactory mongoDatabaseFactory,
-            MongoMappingContext mongoMappingContext
+            MongoMappingContext mongoMappingContext,
+            MongoDatabaseFactory mongoDatabaseFactory
     ) {
         DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory);
         MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);

--- a/src/main/java/com/example/daobe/common/config/RedisConfig.java
+++ b/src/main/java/com/example/daobe/common/config/RedisConfig.java
@@ -16,12 +16,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 @RequiredArgsConstructor
 public class RedisConfig {
 

--- a/src/main/java/com/example/daobe/common/config/ScheduleConfig.java
+++ b/src/main/java/com/example/daobe/common/config/ScheduleConfig.java
@@ -3,6 +3,7 @@ package com.example.daobe.common.config;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -14,23 +15,43 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @Configuration
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "PT10S")
-public class ScheduleConfig implements SchedulingConfigurer {
+public class ScheduleConfig implements SchedulingConfigurer, SmartLifecycle {
 
     private static final String SCHEDULER_EXECUTOR_NAME_PREFIX = "scheduler-task-";
 
-    @Override
-    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+    private final ThreadPoolTaskScheduler taskScheduler = createTaskSchedulerThreadPool();
+
+    private ThreadPoolTaskScheduler createTaskSchedulerThreadPool() {
         ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
         taskScheduler.setPoolSize(1);
         taskScheduler.setAwaitTerminationSeconds(5);
         taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
         taskScheduler.setThreadNamePrefix(SCHEDULER_EXECUTOR_NAME_PREFIX);
-        taskScheduler.initialize();
-        taskRegistrar.setTaskScheduler(taskScheduler);
+        return taskScheduler;
     }
 
     @Bean
     public LockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
         return new RedisLockProvider(redisConnectionFactory);
+    }
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setScheduler(taskScheduler);
+    }
+
+    @Override
+    public void start() {
+        taskScheduler.initialize();
+    }
+
+    @Override
+    public void stop() {
+        taskScheduler.shutdown();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskScheduler.isRunning();
     }
 }

--- a/src/main/java/com/example/daobe/notification/infrastructure/redis/RedisNotificationBroadcastListener.java
+++ b/src/main/java/com/example/daobe/notification/infrastructure/redis/RedisNotificationBroadcastListener.java
@@ -3,28 +3,27 @@ package com.example.daobe.notification.infrastructure.redis;
 import com.example.daobe.notification.application.NotificationSenderService;
 import com.example.daobe.notification.infrastructure.redis.payload.NotificationCreateEventPayload;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jihongkim98.redisextensions.annotation.RedisBroadcastListener;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RedisNotificationBroadcastListener implements MessageListener {
+public class RedisNotificationBroadcastListener {
 
     private final ObjectMapper objectMapper;
     private final NotificationSenderService notificationSenderService;
 
-    @Override
-    public void onMessage(Message message, byte[] pattern) {
-        NotificationCreateEventPayload payload = deserialize(message.getBody());
+    @RedisBroadcastListener(channels = "channel:notification")
+    public void notificationBroadcastListener(String message) {
+        NotificationCreateEventPayload payload = deserialize(message);
         notificationSenderService.sendMessage(payload.notificationId(), payload.senderId());
     }
 
-    private NotificationCreateEventPayload deserialize(byte[] bytes) {
+    private NotificationCreateEventPayload deserialize(String message) {
         try {
-            return objectMapper.readValue(bytes, NotificationCreateEventPayload.class);
+            return objectMapper.readValue(message, NotificationCreateEventPayload.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/example/daobe/notification/infrastructure/redis/RedisNotificationExternalEventBroadcaster.java
+++ b/src/main/java/com/example/daobe/notification/infrastructure/redis/RedisNotificationExternalEventBroadcaster.java
@@ -3,37 +3,21 @@ package com.example.daobe.notification.infrastructure.redis;
 import com.example.daobe.notification.application.NotificationExternalEventBroadcaster;
 import com.example.daobe.notification.domain.event.NotificationCreateEvent;
 import com.example.daobe.notification.infrastructure.redis.payload.NotificationCreateEventPayload;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisNotificationExternalEventBroadcaster implements NotificationExternalEventBroadcaster {
 
-    private static final String NOTIFICATION_CHANNEL_TOPIC = "notification:channel";
+    private static final String NOTIFICATION_CHANNEL_TOPIC = "channel:notification";
 
-    private final ObjectMapper objectMapper;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void execute(NotificationCreateEvent event) {
         NotificationCreateEventPayload payload = NotificationCreateEventPayload.from(event);
-        redisTemplate.convertAndSend(
-                NOTIFICATION_CHANNEL_TOPIC,
-                serialize(payload)
-        );
-    }
-
-    private String serialize(NotificationCreateEventPayload payload) {
-        try {
-            return objectMapper.writeValueAsString(payload);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        redisTemplate.convertAndSend(NOTIFICATION_CHANNEL_TOPIC, payload);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -42,6 +42,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+      repositories:
+        enabled: false
     mongodb:
       uri: mongodb://root:root@localhost:27017/dao-local-db?authSource=admin
       database: dao-local-db


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

스프링 애플리케이션 시작시 데이터 소스 스캔 범위 설정이 정확하게 안되고 있어 발생하던 경고와 애플리케이션 종료시 스케쥴러가 정상적으로 종료되지 않았던 문제 해결 및 [Redis-Extensions](https://github.com/JiHongKim98/redis-extensions) 라이브러리 적용

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 데이터 소스 패키지 스캔 범위 설정 추가
- ✨ 스케쥴러 라이프 사이클 관리 설정 추가
- ✨ `Redis-Extensions` 라이브러리 추가 및 알림 도메인에 적용

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- refs #312
- closed #313 
- closed #314 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

Redis PUB/SUB 로직을 사용하는 도메인인 알림과 채팅 도메인중 알림 도메인은 제가 담당하고 있는 도메인이라서 바로 `redis-extensions` 라이브러리를 적용했습니다.

채팅 도메인은 제가 담당하는 도메인이 아니라서 담당자(준투!!!)와 회의 후 리팩토링을 진행해야할 것 같습니다..!
